### PR TITLE
chore: remove unused sun moon icons

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import ThemeToggle from "./components/controls/ThemeToggle";
 import ManaCost from "./components/cards/ManaCost";
 import CardModal from "./components/cards/CardModal";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { RefreshCcw, Shuffle, Copy, Download, Upload, Settings2, Info, Sparkles, Trash2, Sun, Moon } from "lucide-react";
+import { RefreshCcw, Shuffle, Copy, Download, Upload, Settings2, Info, Sparkles, Trash2 } from "lucide-react";
 
 /**
  * Commander Craft - Générateur de decks MTG Commander


### PR DESCRIPTION
## Summary
- remove Sun and Moon icons from App imports
- ensure only ThemeToggle uses Sun/Moon icons

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689edb31c9008329bf748da9b7698565